### PR TITLE
Fix rounding

### DIFF
--- a/round.go
+++ b/round.go
@@ -5,16 +5,17 @@ import (
 )
 
 // RoundingMode describes how to round a given number.
+// sign is the sign of the number (needed when n is zero)
 // n is the integer that should be rounded such that the last digit is zero.
 // l is the current last digit of n. For most cases you shouldn't need to
 // implement this yourself, use one of the provided implementations in the
 // rounding package.
-type RoundingMode func(n, l *big.Int)
+type RoundingMode func(sign int, n, l *big.Int)
 
-func roundUp(n, l *big.Int) {
+func roundUp(sign int, n, l *big.Int) {
 	li := l.Int64()
 	if li != 0 {
-		if n.Sign() > 0 {
+		if sign > 0 {
 			n.Add(n, l.SetInt64(10-li))
 		} else {
 			n.Sub(n, l.SetInt64(10-li))
@@ -22,17 +23,17 @@ func roundUp(n, l *big.Int) {
 	}
 }
 
-func roundDown(n, l *big.Int) {
-	if n.Sign() > 0 {
+func roundDown(sign int, n, l *big.Int) {
+	if sign > 0 {
 		n.Sub(n, l)
 	} else {
 		n.Add(n, l)
 	}
 }
 
-func roundCeil(n, l *big.Int) {
+func roundCeil(sign int, n, l *big.Int) {
 	li := l.Int64()
-	if n.Sign() > 0 {
+	if sign > 0 {
 		if li != 0 {
 			n.Add(n, l.SetInt64(10-li))
 		}
@@ -41,8 +42,8 @@ func roundCeil(n, l *big.Int) {
 	}
 }
 
-func roundFloor(n, l *big.Int) {
-	if n.Sign() > 0 {
+func roundFloor(sign int, n, l *big.Int) {
+	if sign > 0 {
 		n.Sub(n, l)
 	} else {
 		li := l.Int64()
@@ -52,36 +53,36 @@ func roundFloor(n, l *big.Int) {
 	}
 }
 
-func roundHalfUp(n, l *big.Int) {
+func roundHalfUp(sign int, n, l *big.Int) {
 	if l.Int64() >= 5 {
-		roundUp(n, l)
+		roundUp(sign, n, l)
 	} else {
-		roundDown(n, l)
+		roundDown(sign, n, l)
 	}
 }
 
-func roundHalfDown(n, l *big.Int) {
+func roundHalfDown(sign int, n, l *big.Int) {
 	if l.Int64() > 5 {
-		roundUp(n, l)
+		roundUp(sign, n, l)
 	} else {
-		roundDown(n, l)
+		roundDown(sign, n, l)
 	}
 }
 
-func roundHalfEven(n, l *big.Int) {
+func roundHalfEven(sign int, n, l *big.Int) {
 	li := l.Int64()
 	if li == 5 {
 		k := new(big.Int).Rem(n, big100)
 		ki := k.Int64() / 10
 		if ki%2 == 0 {
-			roundDown(n, l)
+			roundDown(sign, n, l)
 		} else {
-			roundUp(n, l)
+			roundUp(sign, n, l)
 		}
 	} else if li > 5 {
-		roundUp(n, l)
+		roundUp(sign, n, l)
 	} else {
-		roundDown(n, l)
+		roundDown(sign, n, l)
 	}
 }
 
@@ -111,12 +112,13 @@ var (
 // Round sets x to its value rounded to the given precision using the given rounding mode.
 // Returns x, which was modified in place.
 func Round(x *big.Rat, prec int, method RoundingMode) *big.Rat {
+	sign := x.Sign()
 	trunc(x, prec+1)
 	n, d := x.Num(), x.Denom()
 	l := new(big.Int).Rem(n, big10)
 	l.Abs(l)
 
-	method(n, l)
+	method(sign, n, l)
 
 	// To force renormalization
 	return x.SetFrac(n, d)

--- a/round_test.go
+++ b/round_test.go
@@ -18,6 +18,12 @@ func TestRoundUp(t *testing.T) {
 	testRounding(t, "-1.6", "-2", 0, m)
 	testRounding(t, "-2.5", "-3", 0, m)
 	testRounding(t, "-5.5", "-6", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "1", 0, m)
+	testRounding(t, "1.01", "2", 0, m)
+	testRounding(t, "-0.01", "-1", 0, m)
+	testRounding(t, "-1.01", "-2", 0, m)
 }
 
 func TestRoundDown(t *testing.T) {
@@ -32,6 +38,12 @@ func TestRoundDown(t *testing.T) {
 	testRounding(t, "-1.6", "-1", 0, m)
 	testRounding(t, "-2.5", "-2", 0, m)
 	testRounding(t, "-5.5", "-5", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "0", 0, m)
+	testRounding(t, "1.01", "1", 0, m)
+	testRounding(t, "-0.01", "0", 0, m)
+	testRounding(t, "-1.01", "-1", 0, m)
 }
 
 func TestRoundCeil(t *testing.T) {
@@ -46,6 +58,12 @@ func TestRoundCeil(t *testing.T) {
 	testRounding(t, "-1.6", "-1", 0, m)
 	testRounding(t, "-2.5", "-2", 0, m)
 	testRounding(t, "-5.5", "-5", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "1", 0, m)
+	testRounding(t, "1.01", "2", 0, m)
+	testRounding(t, "-0.01", "0", 0, m)
+	testRounding(t, "-1.01", "-1", 0, m)
 }
 
 func TestRoundFloor(t *testing.T) {
@@ -60,6 +78,12 @@ func TestRoundFloor(t *testing.T) {
 	testRounding(t, "-1.6", "-2", 0, m)
 	testRounding(t, "-2.5", "-3", 0, m)
 	testRounding(t, "-5.5", "-6", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "0", 0, m)
+	testRounding(t, "1.01", "1", 0, m)
+	testRounding(t, "-0.01", "-1", 0, m)
+	testRounding(t, "-1.01", "-2", 0, m)
 }
 
 func TestRoundHalfUp(t *testing.T) {
@@ -74,6 +98,12 @@ func TestRoundHalfUp(t *testing.T) {
 	testRounding(t, "-1.6", "-2", 0, m)
 	testRounding(t, "-2.5", "-3", 0, m)
 	testRounding(t, "-5.5", "-6", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "0", 0, m)
+	testRounding(t, "1.01", "1", 0, m)
+	testRounding(t, "-0.01", "0", 0, m)
+	testRounding(t, "-1.01", "-1", 0, m)
 }
 
 func TestRoundHalfDown(t *testing.T) {
@@ -88,6 +118,12 @@ func TestRoundHalfDown(t *testing.T) {
 	testRounding(t, "-1.6", "-2", 0, m)
 	testRounding(t, "-2.5", "-2", 0, m)
 	testRounding(t, "-5.5", "-5", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "0", 0, m)
+	testRounding(t, "1.01", "1", 0, m)
+	testRounding(t, "-0.01", "0", 0, m)
+	testRounding(t, "-1.01", "-1", 0, m)
 }
 
 func TestRoundHalfEven(t *testing.T) {
@@ -102,6 +138,12 @@ func TestRoundHalfEven(t *testing.T) {
 	testRounding(t, "-1.6", "-2", 0, m)
 	testRounding(t, "-2.5", "-2", 0, m)
 	testRounding(t, "-5.5", "-6", 0, m)
+
+	testRounding(t, "0", "0", 0, m)
+	testRounding(t, "0.01", "0", 0, m)
+	testRounding(t, "1.01", "1", 0, m)
+	testRounding(t, "-0.01", "0", 0, m)
+	testRounding(t, "-1.01", "-1", 0, m)
 }
 
 func testRounding(t *testing.T, a, b string, prec int, method RoundingMode) {


### PR DESCRIPTION
When a number such as 1.01 was asked to be rounded to precision 0, we
were not rounding correctly because we only looked 1 decimal place back
and saw a zero there. Fix this by not calling the rounding methods at
all if there is no other precision available and using the knowledge to
know when to round up from 1.01.

Added a bunch of test numbers to test this and other potential issue
cases.

Fixes #1